### PR TITLE
Add option for custom formatter

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,9 @@ Usage
 
 Use ``--docs [PATH]`` to create the documentation.
 
-Use ``--doc-type`` to select the type (currently supports ``md`` and ``rst``)
+Use ``--doc-type`` to select the type (currently supports ``md``, ``rst`` and ``custom``)
+
+Use ``--custom-formatter-path`` when using ``custom`` type, and specify the module path to a python file with a formatter called ``CustomFormatter``. To create a custom formatter, take inspiration from the formatters in the pytest_docs/formatters folder.
 
 Use  ``@pytest.mark.pytest_doc(name="Test Class")`` to override name of element. It'll override name based on the place it is being used (module, class or function).
 

--- a/pytest_docs/element.py
+++ b/pytest_docs/element.py
@@ -169,5 +169,5 @@ class Element:
 
     def __eq__(self, other):
         if not isinstance(other, Element):
-            raise TypeError
+            raise TypeError("Comparison must be of type 'Element'")
         return self.unique_id == other.unique_id

--- a/pytest_docs/plugin.py
+++ b/pytest_docs/plugin.py
@@ -1,12 +1,15 @@
+from argparse import ArgumentError
 from pathlib import Path
 
 from .element import Element
 from .formatters.markdown import MarkdownFormatter
 from .formatters.restuctured import RSTFormatter
 
-FORMATTERS = {
+
+formatters = {
     MarkdownFormatter.name: MarkdownFormatter(),
     RSTFormatter.name: RSTFormatter(),
+    "custom": "Not implemented",
 }
 
 
@@ -18,7 +21,7 @@ class DocPlugin:
     def pytest_runtestloop(self, session):
         doc_tree = Element.create_doc_tree(session.items)
 
-        fmt = FORMATTERS[self.format_type]
+        fmt = formatters[self.format_type]
         out = fmt.create_document(doc_tree)
 
         with Path(self.path).open("w", encoding="utf-8") as file:
@@ -36,12 +39,24 @@ def pytest_addoption(parser):
         dest="docs_type",
         default="md",
         help="Choose document type",
-        choices=list(FORMATTERS),
+        choices=list(formatters),
     )
+    group.addoption(
+        "--custom-formatter-path",
+        dest="custom_formatter_path",
+        help="Choose custom formatter path",
+    )
+
 
 
 def pytest_configure(config):
     path = config.getoption("docs_path")
     if path:
+        custom_fmt_path = config.getoption("custom_formatter_path")
+        if custom_fmt_path is not None:
+            fmt_module = __import__(custom_fmt_path, fromlist=['CustomFormatter'])
+            fmt_class = getattr(fmt_module, 'CustomFormatter')
+            formatters.update({"custom": fmt_class()}) 
+
         format_type = config.getoption("docs_type")
         config.pluginmanager.register(DocPlugin(path, format_type), "pytest-docs")

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name="pytest-docs",
-    version="0.1.0",
+    version="0.2.0",
     author="Or Carmi",
     author_email="or.carmi82@gmail.com",
     maintainer="Or Carmi",

--- a/tests/formatters_for_test/empty_formatter.py
+++ b/tests/formatters_for_test/empty_formatter.py
@@ -1,0 +1,43 @@
+from pytest_docs.formatter import Formatter
+
+
+
+class CustomFormatter(Formatter):
+    name = "md"
+    marker_prefix = ""
+
+    @staticmethod
+    def module_name_format(element):
+        return ""
+    @staticmethod
+    def class_name_format(element):
+        return ""
+
+    @staticmethod
+    def func_name_format(element):
+        return ""
+
+    @staticmethod
+    def marker_format(marker):
+        return ""
+
+
+class DummyCustomFormatter(Formatter):
+    name = "md"
+    marker_prefix = "\n"
+
+    @staticmethod
+    def module_name_format(element):
+        return "# {}".format(element)
+
+    @staticmethod
+    def class_name_format(element):
+        return "## {}".format(element)
+
+    @staticmethod
+    def func_name_format(element):
+        return "### {}".format(element)
+
+    @staticmethod
+    def marker_format(marker):
+        return ""

--- a/tests/formatters_for_test/empty_formatter.py
+++ b/tests/formatters_for_test/empty_formatter.py
@@ -20,24 +20,3 @@ class CustomFormatter(Formatter):
     @staticmethod
     def marker_format(marker):
         return ""
-
-
-class DummyCustomFormatter(Formatter):
-    name = "md"
-    marker_prefix = "\n"
-
-    @staticmethod
-    def module_name_format(element):
-        return "# {}".format(element)
-
-    @staticmethod
-    def class_name_format(element):
-        return "## {}".format(element)
-
-    @staticmethod
-    def func_name_format(element):
-        return "### {}".format(element)
-
-    @staticmethod
-    def marker_format(marker):
-        return ""

--- a/tests/test_pytest_docs.py
+++ b/tests/test_pytest_docs.py
@@ -37,3 +37,14 @@ def test_formatter_sanity(testdir, tmpdir, file_type, expected_file, expected_ou
     testdir.makepyfile(TEST_SUITE)
     testdir.runpytest("--docs", str(path), "--doc-type", file_type)
     assert path.read() == expected_output(expected_file)
+
+def test_custom_formatter(testdir, tmpdir,):
+    file_type = "custom"
+    path = tmpdir.join("doc.{}".format(file_type))
+    testdir.makepyfile(TEST_SUITE)
+    testdir.runpytest(
+        "--docs", str(path),
+        "--doc-type", file_type,
+        "--custom-formatter-path", "tests.formatters_for_test.empty_formatter"
+    )
+    assert "#" not in path.read()


### PR DESCRIPTION
Hi,

I have expanded the pytest options with `--custom-formatter-path` where you can input a module path to a file containing the class `CustomFormatter`.